### PR TITLE
Add an environment variable to support customized App flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ jobs:
       env:
        GITHUB_TOKEN: ${{ secrets.TOKEN }}
        APP_FOLDER: app
+       APP_FLAVOR: ""
 ```
 
 ## Secrets
@@ -57,7 +58,8 @@ I am not sure as to why using the default `GITHUB_TOKEN` provided universally wi
 
 ## Environment Variables
 You'll need to provide these environment variables to specify exactly what information is needed to build the APK.
-* **APP_FOLDER**: main folder to search for the apk. Most of the time, it's `app`
+* **APP_FOLDER**: main folder to search for the apk. Most of the time, it's `app`.
+* **APP_FLAVOR**: app flavor you want to specify. By default, it's empty.
 
 ---
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-hub release create -a ./${APP_FOLDER}/build/outputs/apk/release/**.apk -m "v${GITHUB_REF##*/}" ${GITHUB_REF##*/} 
+flavor=""
+if [ "${APP_FLAVOR}" == "" ]; then
+    echo "default flavor"
+else
+    flavor="${APP_FLAVOR}/"
+    echo "appended flavor : $flavor"
+fi
+
+hub release create -a ./${APP_FOLDER}/build/outputs/apk/${flavor}release/**.apk -m "v${GITHUB_REF##*/}" ${GITHUB_REF##*/}


### PR DESCRIPTION
Better support locating the generated apk path by allowing customized App flavor.

The default folder won't contain the target apk if we have different flavors
```
productFlavors {
    dev {

    }
    prod {

    }
}
``` 
```
Attaching release asset `./app/build/outputs/apk/release/**.apk'...
Error uploading release asset: stat ./app/build/outputs/apk/release/**.apk: no such file or directory
```